### PR TITLE
Fix other middleware return values being chewed up

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,13 +63,11 @@ const createMiddleware = () => {
       case WEBSOCKET_CONNECT:
         close();
         initialize(store, action.payload);
-        next(action);
         break;
 
       // User request to disconnect
       case WEBSOCKET_DISCONNECT:
         close();
-        next(action);
         break;
 
       // User request to send a message
@@ -79,12 +77,9 @@ const createMiddleware = () => {
         } else {
           console.warn('WebSocket is closed, ignoring. Trigger a WEBSOCKET_CONNECT first.');
         }
-        next(action);
         break;
-
-      default:
-        next(action);
     }
+    return next(action);
   };
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -24,6 +24,17 @@ describe('middleware', () => {
     td.verify(next(action));
   });
 
+  it('should return values from next middlewares', () => {
+    const expected = { dunno: 'Something a middleware could return (e.g. a promise)' };
+    const action = { type: 'ACTION' };
+    const next = td.func('next');
+    td.when(next(action)).thenReturn(expected);
+
+    const actual = middleware()(next)(action);
+
+    expect(actual).toBe(expected);
+  });
+
   context('createWebsocket', () => {
      it('should accept a default payload', () => {
        const payload = { url: 'ws://localhost' };


### PR DESCRIPTION
This breaks things like awaiting a promise (with [redux-promise-middleware](https://github.com/pburtchaell/redux-promise-middleware)) or anything else that expects a return value from `dispatch`.

